### PR TITLE
Update kubecolor.rb

### DIFF
--- a/Formula/kubecolor.rb
+++ b/Formula/kubecolor.rb
@@ -6,7 +6,7 @@ class Kubecolor < Formula
   desc "Colorize your kubectl output"
   homepage "https://github.com/dty1er/kubecolor"
   version "0.0.20"
-  bottle :unneeded
+#  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/dty1er/kubecolor/releases/download/v0.0.20/kubecolor_0.0.20_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
```
Tapping dty1er/tap
==> Tapping dty1er/tap
Cloning into '/opt/homebrew/Library/Taps/dty1er/homebrew-tap'...
Error: Invalid formula: /opt/homebrew/Library/Taps/dty1er/homebrew-tap/Formula/kubecolor.rb
kubecolor: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the dty1er/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/dty1er/homebrew-tap/Formula/kubecolor.rb:9

Error: Cannot tap dty1er/tap: invalid syntax in tap!
```